### PR TITLE
ci: Fix Docker Build Workflows for up-to-date Cloud Run Build.

### DIFF
--- a/.github/workflows/docker-build-on-push.yml
+++ b/.github/workflows/docker-build-on-push.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   IMAGE_NAME: "ghcr.io/${{ github.repository_owner }}/label-studio"
-  TAGS: "latest,dev"  # Example tags, set as needed
+  TAGS: "latest"  
   BASE_DOCKER_IMAGE_VERSION: "1.0"  # Example version, set as needed
   DOCKERFILE_PATH: "Dockerfile"  # Example path, set as needed
   REF: ${{ github.ref }}
@@ -43,11 +43,6 @@ jobs:
             const docker_tags = tags.map(x => `${image_name}:${x}`).join(',');
             console.log(docker_tags);
             core.setOutput("docker-tags", docker_tags);
-
-      - name: Edit Dockerfile
-        run: |
-          sed -i "s#^FROM .*#FROM ${IMAGE_NAME}:${BASE_DOCKER_IMAGE_VERSION}#g" "${DOCKERFILE_PATH}"
-          cat "${DOCKERFILE_PATH}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.3.0

--- a/.github/workflows/docker-build-on-push.yml
+++ b/.github/workflows/docker-build-on-push.yml
@@ -1,0 +1,72 @@
+name: "Docker build & push on push"
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  IMAGE_NAME: "ghcr.io/${{ github.repository_owner }}/label-studio"
+  TAGS: "latest,dev"  # Example tags, set as needed
+  BASE_DOCKER_IMAGE_VERSION: "1.0"  # Example version, set as needed
+  DOCKERFILE_PATH: "Dockerfile"  # Example path, set as needed
+  REF: ${{ github.ref }}
+  
+
+jobs:
+  docker_build_and_push:
+    name: "Docker image"
+    timeout-minutes: 90
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/debug-action@v3.0.0
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+          ref: ${{ env.REF }}
+          fetch-depth: 0
+
+      - name: Calculate Docker tags
+        id: calculate-docker-tags
+        uses: actions/github-script@v7
+        env:
+          TAGS: ${{ env.TAGS }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+        with:
+          script: |
+            const raw_tags_input = process.env.TAGS;
+            const image_name = process.env.IMAGE_NAME;
+            
+            const tags = raw_tags_input.split(',').map(x => x.trim());
+            const docker_tags = tags.map(x => `${image_name}:${x}`).join(',');
+            console.log(docker_tags);
+            core.setOutput("docker-tags", docker_tags);
+
+      - name: Edit Dockerfile
+        run: |
+          sed -i "s#^FROM .*#FROM ${IMAGE_NAME}:${BASE_DOCKER_IMAGE_VERSION}#g" "${DOCKERFILE_PATH}"
+          cat "${DOCKERFILE_PATH}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.3.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Docker image
+        uses: docker/build-push-action@v5.3.0
+        id: docker_build_and_push
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE_PATH }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.calculate-docker-tags.outputs.docker-tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-ontop.yml
+++ b/.github/workflows/docker-build-ontop.yml
@@ -7,37 +7,44 @@ on:
         description: 'Base Docker Image version'
         type: string
         required: true
+        default: "1"
       tags:
         description: 'Comma separated tags'
         type: string
         required: true
+        default: "latest"
       dockerfile_path:
         description: "Dockerfile path"
         type: string
         required: true
+        default: "Dockerfile"
       ref:
         description: "Dockerfile ref or sha"
         type: string
         required: true
+        default: "master"
   workflow_dispatch:
     inputs:
       base_docker_image_version:
         description: 'Base Docker Image version'
         type: string
         required: true
+        default: "1"
       tags:
         description: 'Comma separated tags'
         type: string
         required: true
+        default: "latest"
       dockerfile_path:
         description: "Dockerfile path"
         type: string
         required: true
+        default: "Dockerfile"
       ref:
         description: "Dockerfile ref or sha"
         type: string
         required: true
-        default: develop
+        default: master
 
 env:
   IMAGE_NAME: "ghcr.io/${{ github.repository_owner }}/label-studio"

--- a/.github/workflows/docker-build-ontop.yml
+++ b/.github/workflows/docker-build-ontop.yml
@@ -40,7 +40,7 @@ on:
         default: develop
 
 env:
-  IMAGE_NAME: "${{ vars.DOCKERHUB_ORG }}/label-studio"
+  IMAGE_NAME: "ghcr.io/${{ github.repository_owner }}/label-studio"
 
 jobs:
   docker_build_and_push:
@@ -84,11 +84,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.3.0
 
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@v3.1.0
         with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Docker image
         uses: docker/build-push-action@v5.3.0

--- a/Dockerfile.cloudrun
+++ b/Dockerfile.cloudrun
@@ -1,3 +1,3 @@
-FROM us-west1-docker.pkg.dev/potent-symbol-338722/docker-repo/label-studio:latest
+FROM ghcr.io/Open-Paws/label-studio:latest
 ENV LABEL_STUDIO_ONE_CLICK_DEPLOY=1 \
     STORAGE_PERSISTENCE=1


### PR DESCRIPTION
With the following changes, this repository will automatically generate a GHCR container upon each push, which can be directly deployed using the Cloud Run button in the README.

1. **Switched Container Registry**: Moved from Docker Hub to GitHub Container Repository (GHCR) for potential increased flexibility, while also making use of our existing GitHub organization setup.
2. **Default Workflow Inputs**: Added default inputs to the "docker-build-ontop" workflow for easier manual running. Note: this file may not be needed given #3.
3. **Automated Container Builds**: Created a new workflow derived from "docker-build-ontop" that builds containers automatically without needing manually set inputs, pushing them directly to GHCR. Workflow file is `docker-build-on-push.yml`.
4. **Fixed Dockerfile Build Error in Workflow**: Removed a problematic step in `docker-build-on-push.yml` that erroneously modified the Dockerfile, eliminating a referenced build stage, causing an error. Note: `docker-build-ontop.yml` still contains the error-causing step. If the file is still useful, we can remove the step.
5. **Updated Cloud Run Deployment**: Adjusted the Cloud Run button to deploy using the newly automated container builds from GHCR.

Note: We can also shift #3 and #5 to use [Google Cloud Build](https://cloud.google.com/build/docs/automate-builds). 