### PR TITLE
fix: Container Build on Push Workflow Requires Lowercase Repo Name

### DIFF
--- a/.github/workflows/docker-build-on-push.yml
+++ b/.github/workflows/docker-build-on-push.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           script: |
             const raw_tags_input = process.env.TAGS;
-            const image_name = process.env.IMAGE_NAME;
+            const image_name = process.env.IMAGE_NAME.toLowerCase();
             
             const tags = raw_tags_input.split(',').map(x => x.trim());
             const docker_tags = tags.map(x => `${image_name}:${x}`).join(',');

--- a/Dockerfile.cloudrun
+++ b/Dockerfile.cloudrun
@@ -1,3 +1,3 @@
-FROM ghcr.io/Open-Paws/label-studio:latest
+FROM ghcr.io/open-paws/label-studio:latest
 ENV LABEL_STUDIO_ONE_CLICK_DEPLOY=1 \
     STORAGE_PERSISTENCE=1


### PR DESCRIPTION
Fixes this error in GitHub Actions regarding the `.github/workflows/docker-build-on-push.yml` file:
![image](https://github.com/Open-Paws/Human-Feedback-Label-Studio/assets/55062649/d6151743-377d-41a2-a8a8-3cdb005f9042)

Acceptance Criteria:
- Ensure that the docker-build-on-push workflow in GitHub Actions completes successfully,
  and that the built container appears in GHCR.
- Ensure that cloudrun is able to find the image in GHCR.

Already tested and working on my own branch, which didn't get the error initially due to my username already being lowercase. "Open-Paws" on the other hand is mixed-case. 

Dashes are OK according to https://docs.docker.com/reference/cli/docker/image/tag/
> PATH: The path consists of slash-separated components. Each component may contain lowercase letters, digits and separators. A separator is defined as a period, one or two underscores, or one or more hyphens.
