### PR TITLE
fix: Enable Non-Star Icons & feat: Make Rating Icons Green

### DIFF
--- a/web/libs/editor/src/assets/styles/global.scss
+++ b/web/libs/editor/src/assets/styles/global.scss
@@ -108,3 +108,7 @@
 .react-dropdown-tree-select .node.disabled > label > input {
   opacity: 0;
 }
+
+.ant-rate-star-full .ant-rate-star-second {
+  color: #7de480;
+}

--- a/web/libs/editor/src/tags/control/Rating.jsx
+++ b/web/libs/editor/src/tags/control/Rating.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Rate } from "antd";
 import { inject, observer } from "mobx-react";
 import { types } from "mobx-state-tree";
-import { StarOutlined } from "@ant-design/icons";
+import { StarOutlined, HeartOutlined, FireOutlined, SmileOutlined } from "@ant-design/icons";
 
 import RequiredMixin from "../../mixins/Required";
 import PerRegionMixin from "../../mixins/PerRegion";
@@ -143,6 +143,18 @@ const HtxRating = inject("store")(
       iconSize = 40;
     }
 
+    const renderRatingIcon = () => {
+      const iconMap = {
+        heart: HeartOutlined,
+        fire: FireOutlined,
+        smile: SmileOutlined,
+        star: StarOutlined,
+      };
+
+      const IconComponent = iconMap[item.icon] || StarOutlined;
+      return <IconComponent style={{ fontSize: iconSize }} />;
+    };
+
     const visibleStyle = item.perRegionVisible() ? {} : { display: "none" };
 
     // rc-rate component listens for keypress event and hit the star if the key is Enter
@@ -162,7 +174,7 @@ const HtxRating = inject("store")(
     return (
       <div style={visibleStyle} onKeyDownCapture={dontBreakSubmit}>
         <Rate
-          character={<StarOutlined style={{ fontSize: iconSize }} />}
+          character={renderRatingIcon}
           value={item.rating}
           count={Number(item.maxrating)}
           defaultValue={Number(item.defaultvalue)}


### PR DESCRIPTION
Fixes bug preventing non-star Rating icons such as "fire," "smile," and "heart" from appearing.

Additionally, Rating icons are now a pastel green instead of yellow for visual aesthetics and theming.
I confirmed this is Color-Blind friendly on https://pilestone.com/pages/color-blindness-simulator-1

![image](https://github.com/Open-Paws/Human-Feedback-Label-Studio/assets/55062649/97ff203e-385f-4038-80bf-7deaee626590)

Acceptance Criteria:
- When the icon attribute is set to "heart", the HeartOutlined icon should render.
- When the icon attribute is set to "fire", the FireOutlined icon should render.
- When the icon attribute is set to "smile", the SmileOutlined icon should render.
- When the icon attribute is set to "star", the StarOutlined icon should render.
- When no icon is set, the StarOutlined icon should render.
- When an unrecognized icon is set, the StarOutlined icon should render.
- Rating Annotations should export correctly, with the correct values.
- All rating icons (HeartOutlined, FireOutlined, SmileOutlined, StarOutlined) should display in pastel green.
- The green icons should be visible in all parts of the application where rating icons are used.

Tested locally and working as expected.